### PR TITLE
Switch tabs to four spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,39 +1,39 @@
 var asyncWaterfall = require('async-waterfall'),
-	ensureArray = require('ensure-array');
+    ensureArray = require('ensure-array');
 
 module.exports = function () {
-	var middleware = ensureArray.apply(null, arguments),
+    var middleware = ensureArray.apply(null, arguments),
         first = middleware[0],
         useParamValue = 'function' === typeof first && (first.length === 2 || first.length === 4);
-    
-	function async(req, res, next, param) {
-		var context = this;
-        
-		function toAsync(target) {
-			return function () {
-				var next = arguments[arguments.length - 1],
+
+    function async(req, res, next, param) {
+        var context = this;
+
+        function toAsync(target) {
+            return function () {
+                var next = arguments[arguments.length - 1],
                     values = [].slice.call(arguments, 0, -1);
 
                 if (useParamValue) {
                     values.unshift(param);
                 }
-                
-                target.apply(context, [req, res, next].concat(values));
-			};
-		}
 
-		asyncWaterfall(middleware.map(toAsync), function (err) {
-			next(err);
-		});
-	}
-                                                           
-	if (useParamValue) {
-		return function (req, res, next, value) {
-			async(req, res, next, value);
-		};
-	} else {
-		return function (req, res, next) {
-			async(req, res, next);
-		};
-	}
+                target.apply(context, [req, res, next].concat(values));
+            };
+        }
+
+        asyncWaterfall(middleware.map(toAsync), function (err) {
+            next(err);
+        });
+    }
+
+    if (useParamValue) {
+        return function (req, res, next, value) {
+            async(req, res, next, value);
+        };
+    } else {
+        return function (req, res, next) {
+            async(req, res, next);
+        };
+    }
 };


### PR DESCRIPTION
The index file was using a mix of tabs and spaces which made reading a little tricky using GitHub's source viewer since it uses 8 space tabs.
